### PR TITLE
pre-alpha release - Added git url and homepage in package.json for NPM

### DIFF
--- a/plugins/dai-release-backend/package.json
+++ b/plugins/dai-release-backend/package.json
@@ -12,6 +12,11 @@
   "backstage": {
     "role": "backend-plugin"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/digital-ai/backstage-release.git"
+  },
+  "homepage": "https://digital.ai/",
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",

--- a/plugins/dai-release-common/package.json
+++ b/plugins/dai-release-common/package.json
@@ -14,6 +14,11 @@
   "backstage": {
     "role": "common-library"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/digital-ai/backstage-release.git"
+  },
+  "homepage": "https://digital.ai/",
   "sideEffects": false,
   "scripts": {
     "build": "backstage-cli package build",

--- a/plugins/dai-release/package.json
+++ b/plugins/dai-release/package.json
@@ -12,6 +12,11 @@
   "backstage": {
     "role": "frontend-plugin"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/digital-ai/backstage-release.git"
+  },
+  "homepage": "https://digital.ai/",
   "sideEffects": false,
   "scripts": {
     "start": "backstage-cli package start",


### PR DESCRIPTION
The homepage and github url was not displayed in NPM repository.
Added git url and homepage in package.json for NPM
Its a review comment fix from backstage team.
https://github.com/backstage/backstage/pull/24950